### PR TITLE
se suben cambios para cumplir con los requerimientos del reto número 1 usuario Juan Diego Muñoz Ospina

### DIFF
--- a/src/main/java/co/com/techskill/lab2/library/service/dummy/PetitionService.java
+++ b/src/main/java/co/com/techskill/lab2/library/service/dummy/PetitionService.java
@@ -34,6 +34,26 @@ public class PetitionService {
         petitions.add(new PetitionDTO("0ff09c9e-5", "LEND", 6, "11b553eb-b", LocalDate.parse("2025-07-25")));
         petitions.add(new PetitionDTO("86084e60-e", "RETURN", 7, "11b553eb-b", LocalDate.parse("2025-07-25")));
         petitions.add(new PetitionDTO("742330cf-0", "LEND", 6, "12a13228-0", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-1", "LEND", 8, "6600ab76-3", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-2", "RETURN", 9, "12a13228-0", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-3", "LEND", 10, "51ed516f-a", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-4", "RETURN", 8, "11b553eb-b", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-5", "LEND", 9, "297c17d8-4", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-6", "RETURN", 10, "3c24c2fa-3", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-7", "LEND", 8, "eb25c2d4-7", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-8", "RETURN", 9, "1940136a-2", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-9", "LEND", 10, "6600ab76-3", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-10", "RETURN", 8, "12a13228-0", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-11", "LEND", 9, "51ed516f-a", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-12", "RETURN", 10, "11b553eb-b", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-13", "LEND", 8, "297c17d8-4", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-14", "RETURN", 9, "3c24c2fa-3", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-15", "LEND", 10, "eb25c2d4-7", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-16", "RETURN", 8, "1940136a-2", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-17", "LEND", 9, "6600ab76-3", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-18", "RETURN", 10, "12a13228-0", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-19", "LEND", 8, "51ed516f-a", LocalDate.parse("2025-07-25")));
+        petitions.add(new PetitionDTO("z-20", "RETURN", 9, "11b553eb-b", LocalDate.parse("2025-07-25")));
     }
 
     public Flux<PetitionDTO> dummyFindAll(){

--- a/src/main/java/co/com/techskill/lab2/library/web/dummy/PetitionDummyResource.java
+++ b/src/main/java/co/com/techskill/lab2/library/web/dummy/PetitionDummyResource.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 @RestController
 @RequestMapping("/dummy/petitions")
 public class PetitionDummyResource {
@@ -25,5 +27,28 @@ public class PetitionDummyResource {
     public Mono<ResponseEntity<PetitionDTO>> findByPetitionId(@RequestBody PetitionDTO petitionDTO){
         return petitionService.dummyFindById(petitionDTO.getPetitionId())
                 .map(ResponseEntity::ok);
+    }
+
+    /**
+     * Gets petitions with priority greater than 7, simulating a reactive stream processing.
+     * @return a Flux of PetitionDTO with high priority.
+     */
+    @GetMapping("/high-priority")
+    public Flux<PetitionDTO> getHighPriorityPetitions() {
+        return petitionService.dummyFindAll()
+                .doOnNext(petition -> System.out.println("--- Initial stream --- Received: " + petition.getPetitionId() + " | Priority: " + petition.getPriority()))
+                .limitRate(20) // First rate limit to control backpressure from the source
+                .delayElements(Duration.ofMillis(500)) // Simulate processing time for each element (20 * 50ms = 1s)
+                .filter(petition -> petition.getPriority() > 7)
+                .doOnNext(filteredPetition -> System.out.println(">>> Filtered stream (Priority > 7) >>> Found: " + filteredPetition.getPetitionId() + " | Priority: " + filteredPetition.getPriority()))
+                .limitRate(1) // Second rate limit to control backpressure for the subscriber
+                .map(finalPetition -> {
+                    System.out.println("<<< Final Mapping Stage <<< Full Info: Petition ID=" + finalPetition.getPetitionId() +
+                            ", Type=" + finalPetition.getType() +
+                            ", Priority=" + finalPetition.getPriority() +
+                            ", Book ID=" + finalPetition.getBookId() +
+                            ", Sent At=" + finalPetition.getSentAt());
+                    return finalPetition;
+                });
     }
 }


### PR DESCRIPTION
En la actividad sugerida, se han utilizado varios operadores reactivos, para simular los ratelimit en dos porciones del código, además se definen en otro punto de acceso, donde retornarmos el flux, pero usamos el map para obtener los datos de cada petitions y mostrarlos por la consola.

El flujo esta diseñado para comprobar lo visto en clase, efectivamente se van imprimiendo los datos del flujo que ya están listos, incluso si los que se están filtrando aun no han terminado.

Para mejorar la simulación es mejor subirlo a un segundo.

<img width="899" height="512" alt="image" src="https://github.com/user-attachments/assets/3e2dc5a6-f18b-4c14-aba5-d83ae9b10fea" />
